### PR TITLE
Travis CI: test against Lua 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 sudo: false
 
 env:
-  - LUA="lua=5.2"
+  - LUA="lua=5.3"
 
 before_install:
   - pip install hererocks


### PR DESCRIPTION
darktable uses Lua version 5.3, see https://www.darktable.org/usermanual/en/lua/overview/